### PR TITLE
Use new JobRecord class

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -3,5 +3,9 @@ appraise "sidekiq-5.x" do
 end
 
 appraise "sidekiq-6.x" do
-  gem "sidekiq", "~> 6"
+  gem "sidekiq", "~> 6", "<= 6.2.1"
+end
+
+appraise "sidekiq-6.2.2+" do
+  gem "sidekiq", "~> 6", ">= 6.2.2"
 end

--- a/gemfiles/sidekiq_6.2.2_.gemfile
+++ b/gemfiles/sidekiq_6.2.2_.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "sidekiq", "~> 6", "<= 6.2.1"
+gem "sidekiq", "~> 6", ">= 6.2.2"
 
 gemspec path: "../"


### PR DESCRIPTION
`Sidekiq::Job` has been repurposed by https://github.com/mperham/sidekiq/commit/f1b24da9c225a5512120514d32a5348760e92f3a
It is still necessary to use `Sidekiq::Job` for existing versions of Sidekiq but from version 6.2.2 and onwards `Sidekiq::JobRecord` must be used.