### PR TITLE
Fix redis deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+**Version 2.1.3**
+* Fixes redis deprecation warnings (https://github.com/kenaniah/sidekiq-status/issues/11)
+
 **Version 2.1.2**
  * Casts values to strings when HTML-encoding
 

--- a/lib/sidekiq-status/storage.rb
+++ b/lib/sidekiq-status/storage.rb
@@ -13,10 +13,10 @@ module Sidekiq::Status::Storage
   # @return [String] Redis operation status code
   def store_for_id(id, status_updates, expiration = nil, redis_pool=nil)
     redis_connection(redis_pool) do |conn|
-      conn.multi do
-        conn.hmset  key(id), 'update_time', Time.now.to_i, *(status_updates.to_a.flatten(1))
-        conn.expire key(id), (expiration || Sidekiq::Status::DEFAULT_EXPIRY)
-        conn.publish "status_updates", id
+      conn.multi do |pipeline|
+        pipeline.hmset  key(id), 'update_time', Time.now.to_i, *(status_updates.to_a.flatten(1))
+        pipeline.expire key(id), (expiration || Sidekiq::Status::DEFAULT_EXPIRY)
+        pipeline.publish "status_updates", id
       end[0]
     end
   end


### PR DESCRIPTION
This PR fixes deprecation warnings of redis:

```
(called from /home/blackst0ne/.asdf/installs/ruby/2.7.5/lib/ruby/gems/2.7.0/gems/sidekiq-status-2.1.2/lib/sidekiq-status/storage.rb:16:in `block in store_for_id'}
.....................................Pipelining commands on a Redis instance is deprecated and will be removed in Redis 5.0.0.

redis.pipelined do
  redis.get("key")
end

should be replaced by

redis.pipelined do |pipeline|
  pipeline.get("key")
end
```