### PR TITLE
Require sidekiq/component in ServerMiddleware

### DIFF
--- a/lib/sidekiq-status/server_middleware.rb
+++ b/lib/sidekiq-status/server_middleware.rb
@@ -1,4 +1,5 @@
 if Sidekiq.major_version >= 5
+  require 'sidekiq/component'
   require 'sidekiq/job_retry'
 end
 

--- a/lib/sidekiq-status/server_middleware.rb
+++ b/lib/sidekiq-status/server_middleware.rb
@@ -1,5 +1,5 @@
 if Sidekiq.major_version >= 5
-  require 'sidekiq/component'
+  require 'sidekiq/component' rescue nil
   require 'sidekiq/job_retry'
 end
 


### PR DESCRIPTION
Fixes https://github.com/kenaniah/sidekiq-status/issues/16

Kinda hacky fix for older versions but there's no easy way to detect which minor+patch version of sidekiq is being used