### PR TITLE
[WIP] Fixes for Sidekiq 7

### DIFF
--- a/lib/sidekiq-status/client_middleware.rb
+++ b/lib/sidekiq-status/client_middleware.rb
@@ -39,7 +39,7 @@ module Sidekiq::Status
           worker: JOB_CLASS.new(msg, queue).display_class,
           args: display_args(msg, queue)
         }
-        store_for_id msg['jid'], initial_metadata, job_class.new.expiration || @expiration, redis_pool
+        store_for_id msg['jid'], initial_metadata, (job_class.new.expiration || @expiration).to_s, redis_pool
       end
 
       yield

--- a/lib/sidekiq-status/storage.rb
+++ b/lib/sidekiq-status/storage.rb
@@ -29,7 +29,7 @@ module Sidekiq::Status::Storage
   # @param [ConnectionPool] redis_pool optional redis connection pool
   # @return [String] Redis operation status code
   def store_status(id, status, expiration = nil, redis_pool=nil)
-    store_for_id id, {status: status}, expiration, redis_pool
+    store_for_id id, {status: status}, expiration.to_s, redis_pool
   end
 
   # Unschedules the job and deletes the Status

--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -82,7 +82,8 @@ module Sidekiq::Status
       app.get '/statuses' do
 
         jids = Sidekiq.redis do |conn|
-          conn.scan_each(match: 'sidekiq:status:*', count: 100).map do |key|
+          scan_method = conn.respond_to?(:scan_each) ? :scan_each : :scan
+          conn.public_send(scan_method, match: 'sidekiq:status:*', count: 100).map do |key|
             key.split(':').last
           end.uniq
         end

--- a/lib/sidekiq-status/worker.rb
+++ b/lib/sidekiq-status/worker.rb
@@ -11,7 +11,7 @@ module Sidekiq::Status::Worker
   # @param [Hash] status_updates updated values
   # @return [String] Redis operation status code
   def store(hash)
-    store_for_id @provider_job_id || @job_id || @jid, hash, @expiration
+    store_for_id @provider_job_id || @job_id || @jid, hash, @expiration.to_s
   end
 
   # Read value from job status hash

--- a/sidekiq-status.gemspec
+++ b/sidekiq-status.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency      'colorize'
   gem.add_development_dependency      'rack-test'
   gem.add_development_dependency      'rake'
+  gem.add_development_dependency      'redis'
   gem.add_development_dependency      'rspec'
   gem.add_development_dependency      'sinatra'
 end


### PR DESCRIPTION
When completed, fixes https://github.com/kenaniah/sidekiq-status/issues/20

- [x] Sidekiq Status UI is rendering in Sidekiq dashboard
- [x] Jobs that include `Sidekiq::Status::Worker` enqueue properly
- [x] Client middleware is loading properly with an `expiration` specified
- [ ] All client middleware use cases?
- [ ] `Sidekiq::Status::Worker` methods like `at`?
- [ ] Specs are passing

* Sidekiq 7 only includes redis-client, and the `Sidekiq.redis { |conn| }` connection is a `CompatClient` that wraps a `RedisClient` instance

* On top of that, the `redis`/`redis-client` gem implementations no longer automatically `to_s` many of the arguments handed into them. So things like Time/ActiveSupport::Duration/Booleans/Nil no longer get converted to strings and will blow up with errors like `Unsupported command argument type: NilClass`

* To support `spec_helper.rb` `subscribe_with_timeout`, the `redis` gem is now a development dependency and `Redis.new` is called directly instead of `Sidekiq.redis`

* Usages of `expiration` in `client_middleware`, `storage` and `worker` now apply `.to_s` when being stored

* In `web.rb`, `conn` is checked for whether it supports `scan_each` (`Redis.new` instance) or `scan` (`CompatClient.new(RedisClient.new)` instance)

* These changes fix the web view in sidekiq UI, and allow jobs to be enqueued properly with the sidekiq status middleware.