### PR TITLE
Avoid setting status to jobs that are not Sidekiq::Status::Worker

### DIFF
--- a/spec/lib/sidekiq-status/server_middleware_spec.rb
+++ b/spec/lib/sidekiq-status/server_middleware_spec.rb
@@ -61,6 +61,22 @@ describe Sidekiq::Status::ServerMiddleware do
         end
         expect(redis.hget("sidekiq:status:#{job_id}", :status)).to be_nil
       end
+
+      it "should not set any status on system exit signal" do
+        allow(SecureRandom).to receive(:hex).once.and_return(job_id)
+        start_server do
+          expect(ExitedNoStatusJob.perform_async).to eq(job_id)
+        end
+        expect(redis.hget("sidekiq:status:#{job_id}", :status)).to be_nil
+      end
+
+      it "should not set any status on interrupt signal" do
+        allow(SecureRandom).to receive(:hex).once.and_return(job_id)
+        start_server do
+          expect(InterruptedNoStatusJob.perform_async).to eq(job_id)
+        end
+        expect(redis.hget("sidekiq:status:#{job_id}", :status)).to be_nil
+      end
     end
 
     context "sets interrupted status" do

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -111,7 +111,19 @@ class ExitedJob < StubJob
   end
 end
 
+class ExitedNoStatusJob < StubNoStatusJob
+  def perform
+    raise SystemExit
+  end
+end
+
 class InterruptedJob < StubJob
+  def perform
+    raise Interrupt
+  end
+end
+
+class InterruptedNoStatusJob < StubNoStatusJob
   def perform
     raise Interrupt
   end


### PR DESCRIPTION
When a systemexit/interrupt/Worker::Stopped exception is rescued, the status is set to the jobs, even those that don't include `Sidekiq::Status::Worker`. So this causes us to have many rows in the UI with interrupted state and no initial metadata set:

![Screen Shot 2023-03-30 at 3 43 17 PM](https://user-images.githubusercontent.com/922866/228950442-02881562-96a0-4d73-bc1f-4cb7dce405e9.png)
