### PR TITLE
Move all inline scripts into a separate js file

### DIFF
--- a/lib/sidekiq-status/web.rb
+++ b/lib/sidekiq-status/web.rb
@@ -186,6 +186,14 @@ Sidekiq::Web.register(Sidekiq::Status::Web)
 ["per_page", "sort_by", "sort_dir", "status"].each do |key|
   Sidekiq::WebHelpers::SAFE_QPARAMS.push(key)
 end
+
+ASSETS_PATH = File.expand_path('../../../web/assets', __FILE__)
+
+Sidekiq::Web.use Rack::Static, urls: ['/javascripts'],
+                               root: ASSETS_PATH,
+                               cascade: true,
+                               header_rules: [[:all, { 'cache-control' => 'private, max-age=86400' }]]
+
 if Sidekiq::Web.tabs.is_a?(Array)
   # For sidekiq < 2.5
   Sidekiq::Web.tabs << "statuses"

--- a/web/assets/javascripts/statuses.js
+++ b/web/assets/javascripts/statuses.js
@@ -1,0 +1,7 @@
+var filterSelects = document.querySelectorAll(".nav-container select.form-control")
+for(var i = 0; i < filterSelects.length; i++){
+  filterSelects[i].addEventListener("change", function() {
+    console.log(this)
+    window.location = this.options[this.selectedIndex].getAttribute('data-url')
+  })
+}

--- a/web/views/statuses.erb
+++ b/web/views/statuses.erb
@@ -49,18 +49,13 @@
   margin: 0 0 0 5px;
 }
 </style>
-<script>
-function setPerPage(select){
-  window.location = select.options[select.selectedIndex].getAttribute('data-url')
-}
-</script>
 <div style="display: flex; justify-content: space-between;">
   <h3 class="wi">Recent job statuses</h3>
   <div class="nav-container">
     <%= erb :_paging, locals: { url: "#{root_path}statuses" } %>
     <div class="filter-status">
       Filter Status:
-      <select class="form-control" onchange="setPerPage(this)">
+      <select class="form-control">
         <% (['all', 'complete', 'failed', 'interrupted', 'queued', 'retrying', 'stopped', 'working']).each do |status| %>
           <option data-url="?<%= qparams(status: status)%>" value="<%= status %>" <%= 'selected="selected"' if status == (params[:status]) %>><%= status %></option>
         <% end %>
@@ -69,7 +64,7 @@ function setPerPage(select){
 
     <div class="per-page">
       Per page:
-      <select class="form-control" onchange="setPerPage(this)">
+      <select class="form-control">
         <% (Sidekiq::Status::Web.per_page_opts + ['all']).each do |num| %>
         <option data-url="?<%= qparams(page: 1, per_page: num)%>" value="<%= num %>" <%= 'selected="selected"' if num.to_s == (params[:per_page] || @count) %>><%= num %></option>
         <% end %>
@@ -152,3 +147,5 @@ function setPerPage(select){
     </tr>
   <% end %>
 </table>
+  <script type="text/javascript" src="<%= root_path %>javascripts/statuses.js">
+</script>


### PR DESCRIPTION
Due to Sidekiq 7.2 [changes](https://github.com/sidekiq/sidekiq/pull/6074/files#diff-683b2fd787e04bdaa5af519ad8f45ec9ef8bd7341f5877e69c958ceb34d53918) inline javascripts won't be allowed to run, which is being used for filter select tags on `statuses.erb` file. This PR attempts to move those javascript code into a separate file and add them into sidekiq's static assets.

This resolves https://github.com/kenaniah/sidekiq-status/issues/43