### PR TITLE
Fix job_class evaluation bug

### DIFF
--- a/lib/sidekiq-status/client_middleware.rb
+++ b/lib/sidekiq-status/client_middleware.rb
@@ -22,7 +22,7 @@ module Sidekiq::Status
     def call(worker_class, msg, queue, redis_pool=nil)
 
       # Determine the actual job class
-      klass = msg["args"][0]["job_class"] || worker_class rescue worker_class
+      klass = (!msg["args"][0].is_a?(String) && msg["args"][0]["job_class"]) || worker_class rescue worker_class
       job_class = if klass.is_a?(Class)
                     klass
                   elsif Module.const_defined?(klass)

--- a/lib/sidekiq-status/server_middleware.rb
+++ b/lib/sidekiq-status/server_middleware.rb
@@ -34,7 +34,7 @@ module Sidekiq::Status
       expiry = @expiration
 
       # Determine the actual job class
-      klass = msg["args"][0]["job_class"] || msg["class"] rescue msg["class"]
+      klass = (!msg["args"][0].is_a?(String) && msg["args"][0]["job_class"]) || msg["class"] rescue msg["class"]
       job_class = klass.is_a?(Class) ? klass : Module.const_get(klass)
 
       # Bypass unless this is a Sidekiq::Status::Worker job

--- a/spec/lib/sidekiq-status/client_middleware_spec.rb
+++ b/spec/lib/sidekiq-status/client_middleware_spec.rb
@@ -38,6 +38,14 @@ describe Sidekiq::Status::ClientMiddleware do
       end
     end
 
+    context "when first argument is a string containing substring 'job_class'" do
+      it "uses the constantized class name" do
+        expect(StubJob.perform_async 'a string with job_class inside').to eq(job_id)
+        expect(redis.hget("sidekiq:status:#{job_id}", :status)).to eq('queued')
+        expect(Sidekiq::Status::queued?(job_id)).to be_truthy
+        expect(Sidekiq::Status::get_all(job_id)).to include('worker' => 'StubJob')
+      end
+    end
   end
 
   describe "with :expiration parameter" do


### PR DESCRIPTION
Addresses https://github.com/kenaniah/sidekiq-status/issues/45

When the first argument to a job is a string containing a substring `"job_class"`, job class evaluation code crashes trying to convert that substring to a class.

This PR avoids fetching the class name from the argument, if the first argument is a string.