### PR TITLE
docs: fix YARD param class for sidekiq_config in middlewares

### DIFF
--- a/lib/sidekiq-status/client_middleware.rb
+++ b/lib/sidekiq-status/client_middleware.rb
@@ -57,7 +57,7 @@ module Sidekiq::Status
 
   # Helper method to easily configure sidekiq-status client middleware
   # whatever the Sidekiq version is.
-  # @param [Sidekiq] sidekiq_config the Sidekiq config
+  # @param [Sidekiq::Config] sidekiq_config the Sidekiq config
   # @param [Hash] client_middleware_options client middleware initialization options
   # @option client_middleware_options [Fixnum] :expiration ttl for complete jobs
   def self.configure_client_middleware(sidekiq_config, client_middleware_options = {})

--- a/lib/sidekiq-status/server_middleware.rb
+++ b/lib/sidekiq-status/server_middleware.rb
@@ -88,7 +88,7 @@ module Sidekiq::Status
 
   # Helper method to easily configure sidekiq-status server middleware
   # whatever the Sidekiq version is.
-  # @param [Sidekiq] sidekiq_config the Sidekiq config
+  # @param [Sidekiq::Config] sidekiq_config the Sidekiq config
   # @param [Hash] server_middleware_options server middleware initialization options
   # @option server_middleware_options [Fixnum] :expiration ttl for complete jobs
   def self.configure_server_middleware(sidekiq_config, server_middleware_options = {})


### PR DESCRIPTION
This PR simply fixes `sidekiq_config` param YARD Documentation in middlewares, since it was using `Sidekiq` class and not `Sidekiq::Config` as expected, leading to an IDE warning.