### PR TITLE
Allow running jobs to be stopped

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# A very simple Dockerfile to allow us to run the test suite from docker compose
+FROM ruby:3.3.5
+WORKDIR /app
+COPY . .
+RUN bundle install

--- a/README.md
+++ b/README.md
@@ -263,6 +263,14 @@ Bug reports and pull requests are welcome. This project is intended to be a safe
 5. Push to the branch (`git push origin my-new-feature`)
 6. Create new Pull Request.
 
+### Running the Test Suite
+
+You can use `docker compose` to easily run the test suite:
+
+```
+docker compose run --rm sidekiq-status
+```
+
 ## Thanks
 * Pramod Shinde
 * Kenaniah Cerny

--- a/README.md
+++ b/README.md
@@ -182,6 +182,21 @@ Sidekiq::Status::working_at job_id #=> 2718
 Sidekiq::Status::update_time job_id #=> 2819
 ```
 
+### Stopping a running job
+
+You can ask a job to stop execution by calling `.stop!` with its job ID. The
+next time the jobs calls `.at` it will raise
+`Sidekiq::Status::Worker::Stopped`. It will not attempt to retry.
+
+```ruby
+job_id = MyJob.perform_async
+Sidekiq::Status.stop!  job_id #=> true
+Sidekiq::Status.status job_id #=> :stopped
+```
+
+Note this will not kill a running job that is stuck. The job must call `.at`
+for it to be stopped in this way.
+
 ### Unscheduling
 
 ```ruby

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+# Run the test suite with docker compose
+services:
+  sidekiq-status:
+    build: .
+    environment:
+      - REDIS_URL=redis://redis
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: bundle exec rake
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7.4.0

--- a/lib/sidekiq-status.rb
+++ b/lib/sidekiq-status.rb
@@ -42,6 +42,10 @@ module Sidekiq::Status
       delete_status(job_id)
     end
 
+    def stop!(job_id)
+      store_for_id(job_id, {stop: 'true'})
+    end
+
     alias_method :unschedule, :cancel
 
     STATUS.each do |name|

--- a/lib/sidekiq-status/worker.rb
+++ b/lib/sidekiq-status/worker.rb
@@ -21,7 +21,8 @@ module Sidekiq::Status::Worker
     read_field_for_id @provider_job_id || @job_id || @jid || "", name
   end
 
-  # Sets current task progress
+  # Sets current task progress. This will stop the job if `.stop!` has been
+  # called with this job's ID.
   # (inspired by resque-status)
   # @param Fixnum number of tasks done
   # @param String optional message
@@ -30,6 +31,7 @@ module Sidekiq::Status::Worker
     @_status_total = 100 if @_status_total.nil?
     pct_complete = ((num / @_status_total.to_f) * 100).to_i rescue 0
     store(at: num, total: @_status_total, pct_complete: pct_complete, message: message, working_at: working_at)
+    raise Stopped if retrieve(:stop) == 'true'
   end
 
   # Sets total number of tasks

--- a/spec/lib/sidekiq-status/web_spec.rb
+++ b/spec/lib/sidekiq-status/web_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'sidekiq-status/web'
 require 'rack/test'
+require 'base64'
 
 describe 'sidekiq status web' do
   include Rack::Test::Methods

--- a/spec/lib/sidekiq-status_spec.rb
+++ b/spec/lib/sidekiq-status_spec.rb
@@ -138,6 +138,20 @@ describe Sidekiq::Status do
     end
   end
 
+  describe ".stop!" do
+    it "allows a job to be stopped" do
+      allow(SecureRandom).to receive(:hex).once.and_return(job_id)
+      start_server do
+        expect(capture_status_updates(1) {
+          expect(LongProgressJob.perform_async).to eq(job_id)
+          expect(Sidekiq::Status.stop!(job_id)).to be_truthy
+        }).to eq([job_id]*1)
+      end
+      expect(Sidekiq::Status.at(job_id)).to be(10)
+      expect(Sidekiq::Status.stopped?(job_id)).to be_truthy
+    end
+  end
+
   context "keeps normal Sidekiq functionality" do
     let(:expiration_param) { nil }
 

--- a/spec/support/test_jobs.rb
+++ b/spec/support/test_jobs.rb
@@ -32,6 +32,15 @@ class LongJob < StubJob
   end
 end
 
+class LongProgressJob < StubJob
+  def perform(*args)
+    10.times do
+      at 10
+      sleep (args[0] || 0.25) / 10
+    end
+  end
+end
+
 class DataJob < StubJob
   def perform
     sleep 0.1


### PR DESCRIPTION
This reimplements [resque-status' kill functionality](https://github.com/quirkey/resque-status/tree/master?tab=readme-ov-file#label-Kill-21+Kill-21+Kill-21). Using the verb "kill" always seemed like a misnomer since it will not kill a stuck job.

Instead we've used the verb "stop" since that's what we're asking the job to do. We've taken some liberties by using the "reserved" field "stop" to implement this functionality. It seemed like a natural fit.

Raising `Stopped` also felt like a natural fit. It means the job will not be retried, which is what we want here.

As part of developing this I wanted an easy way to run the specs in docker so I've included a commit that does this too.