### PR TITLE
Add ruby 3.3 and 3.4 to the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,8 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
+          - '3.4'
         gemfile:
           - 'gemfiles/sidekiq_6.1.gemfile'
           - 'gemfiles/sidekiq_6.x.gemfile'


### PR DESCRIPTION
# What
Adding newer ruby versions to the CI. This update includes ruby 3.3, ruby 3.4.