### PR TITLE
Fix Sidekiq version in CI to match the expected one

### DIFF
--- a/gemfiles/sidekiq_6.1.gemfile
+++ b/gemfiles/sidekiq_6.1.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "sidekiq", "~> 6.1"
+gem "sidekiq", "~> 6.1.0"
 
 gemspec path: "../"


### PR DESCRIPTION
With the previous Gemfile constraints, the CI meant for Sidekiq 6.1.x was actually using Sidekiq 6.5.12.
