### PR TITLE
Remove old conditional branch for older Sidekiq versions

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,6 @@
 require "rspec"
 require 'colorize'
 require 'sidekiq'
-
-# Celluloid should only be manually required before Sidekiq versions 4.+
-require 'sidekiq/version'
-require 'celluloid' if Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new('4.0')
-
 require 'sidekiq/processor'
 require 'sidekiq/manager'
 require 'sidekiq-status'


### PR DESCRIPTION
Since the current sidekiq-status supports Sidekiq 6 and above, the branch for versions below 6 is no longer needed and has been removed.
