### PR TITLE
Fix Progress Bars When Live Polling

### DIFF
--- a/web/assets/statuses.js
+++ b/web/assets/statuses.js
@@ -4,21 +4,3 @@ document.addEventListener("change", function(event) {
     window.location = event.target.options[event.target.selectedIndex].getAttribute('data-url')
   }
 })
-
-// Set width of progress bars based on their aria-valuenow attribute
-function updateProgressBarWidths() {
-  document.querySelectorAll('.progress-bar').forEach(function(progressBar) {
-    const valueNow = progressBar.getAttribute('aria-valuenow');
-    if (valueNow !== null) {
-      progressBar.style.width = valueNow + '%';
-    }
-  });
-}
-updateProgressBarWidths();
-
-// Update progress bar widths when the page loads
-document.addEventListener("DOMContentLoaded", updateProgressBarWidths);
-
-// Also update when new content is dynamically loaded
-document.addEventListener("DOMContentMounted", updateProgressBarWidths);
-

--- a/web/views/status.erb
+++ b/web/views/status.erb
@@ -15,7 +15,7 @@
 </h3>
 
 <div class="progress h-30px">
-  <div class="progress-bar" role="progressbar" aria-valuenow="<%= @status["pct_complete"].to_i %>" aria-valuemin="0" aria-valuemax="100">
+  <div class="progress-bar" role="progressbar" data-width="<%= @status["pct_complete"].to_i %>" aria-valuenow="<%= @status["pct_complete"].to_i %>" aria-valuemin="0" aria-valuemax="100">
     <div class="progress-percentage fs-lg">
       <%= @status["pct_complete"].to_i %>%
     </div>

--- a/web/views/statuses.erb
+++ b/web/views/statuses.erb
@@ -56,7 +56,7 @@
       </td>
       <td>
         <div class="progress" class="mb-0">
-          <div class="progress-bar" role="progressbar" aria-valuenow="<%= container["pct_complete"].to_i %>" aria-valuemin="0" aria-valuemax="100">
+          <div class="progress-bar" role="progressbar" data-width="<%= container["pct_complete"].to_i %>"  aria-valuenow="<%= container["pct_complete"].to_i %>" aria-valuemin="0" aria-valuemax="100">
             <div class="progress-percentage">
               <%= container["pct_complete"].to_i %>%
             </div>


### PR DESCRIPTION
This is happening because when live polling is enabled the custom function `updateProgressBarWidths` isn't being called. The custom functions aren't necessary since the main Sidekiq project has a function called [`updateProgressBars`](https://github.com/sidekiq/sidekiq/blob/67187515db817c7fa77b680d81c8cc48f0fb35ae/web/assets/javascripts/application.js#L186-L188) that will automatically change the width assuming that the the element has a `data-width` property.

I have tested this locally on a Rails 8 application and here is what happens in `main`:

<img width="1308" height="548" alt="Screenshot 2025-10-30 at 12 25 59 AM" src="https://github.com/user-attachments/assets/32b9647e-5d42-4db5-9b3c-52bce40b68e4" />

And this is with the fix applied from this branch:

<img width="1308" height="548" alt="Screenshot 2025-10-30 at 12 19 13 AM" src="https://github.com/user-attachments/assets/84ea1100-f614-4e0d-b884-ae88c82aa2c9" />